### PR TITLE
Display albums in a list format

### DIFF
--- a/src/Albums.js
+++ b/src/Albums.js
@@ -13,7 +13,7 @@ export function Albums() {
   return (
     <>
       <h1>Albums for {params.artist}</h1>
-      {albums}
+      {albums.map((album) => (<li key={album}>{album}</li>))}
     </>
   );
 }


### PR DESCRIPTION
Rather than having a long string of albums, just map each album into a
`<li>` element.